### PR TITLE
Implements stream.finished() for better error handling.

### DIFF
--- a/lib/AbstractDownloadSession.js
+++ b/lib/AbstractDownloadSession.js
@@ -1,6 +1,7 @@
 const EventEmitter = require("events")
 const fjs = require("functional.js")
 const Utils = require('./Utils')
+const { finished } = require('stream')
 
 module.exports = class extends EventEmitter {
     constructor(url, savePath) {
@@ -97,7 +98,9 @@ module.exports = class extends EventEmitter {
                 this._emitProgress();
             }
         });
-        res.on('end', () => this._emitEnd());
-        res.on('error', (e) => this._emitError(e));
+        finished(res, e => e
+            ? this._emitError(e)
+            : this._emitEnd()
+        );
     }
 };

--- a/lib/DownloadSession.js
+++ b/lib/DownloadSession.js
@@ -2,6 +2,7 @@ const http = require("http")
 const https = require("https")
 const fs = require("fs")
 const url = require("url")
+const { finished } = require('stream')
 const AbstractDownloadSession = require("./AbstractDownloadSession");
 
 module.exports = class extends AbstractDownloadSession {
@@ -55,13 +56,16 @@ module.exports = class extends AbstractDownloadSession {
         }
         requestOptions.timeout = 3000;
         const httpLibrary = requestOptions.protocol.indexOf("https") === 0 ? https : http;
-        httpLibrary.get(requestOptions, res => {
-            this.lastSecondDownloadedBytes = 0;
-            this.downloadedBytes = 0;
-            this.bytesPerSecond = 0;
-            res.pipe(file);
-            this._handleResponse(res);
-        }).on('error', e => this._emitError(e));
+        finished(
+            httpLibrary.get(requestOptions, res => {
+                this.lastSecondDownloadedBytes = 0;
+                this.downloadedBytes = 0;
+                this.bytesPerSecond = 0;
+                res.pipe(file);
+                this._handleResponse(res);
+            }),
+            e => e && this._emitError(e)
+        );
         this.status = "downloading";
     };
 };

--- a/lib/DownloadWorker.js
+++ b/lib/DownloadWorker.js
@@ -8,6 +8,7 @@ const https        = require("https")
 const url          = require("url")
 const Utils        = require('./Utils')
 const path         = require("path")
+const { finished } = require('stream')
 
 
 module.exports = class extends EventEmitter {
@@ -49,7 +50,12 @@ module.exports = class extends EventEmitter {
                 this.emit("error", {"code": "ERROR_BAD_STATUS_CODE", "message": "Target is not downloadable, server didn't response with 200 code."});
             }
         });
-        request.on('error', err => this.emit("error", {"code": "ERROR_CONNECT_TO_SERVER", "message": "Can not connect to target server."}));
+        finished(request, e => 
+            e && this.emit("error", {
+                "code": "ERROR_CONNECT_TO_SERVER",
+                "message": "Can not connect to target server."
+            })
+        );
         request.end();
     }
 

--- a/lib/PartialDownloadSession.js
+++ b/lib/PartialDownloadSession.js
@@ -3,6 +3,7 @@ const http = require("http")
 const https = require("https")
 const fs = require("fs")
 const url = require("url")
+const { finished } = require('stream')
 const AbstractDownloadSession = require("./AbstractDownloadSession");
 
 module.exports = class extends AbstractDownloadSession {
@@ -32,7 +33,8 @@ module.exports = class extends AbstractDownloadSession {
             this.bytesPerSecond = 0;
             res.pipe(file);
             this._handleResponse(res);
-        }).on('error', e => this._emitError(e));
+        })
+        finished(res, e => e && this._emitError(e));
         this.status = "downloading";
     };
 };

--- a/lib/SimpleDownloadSession.js
+++ b/lib/SimpleDownloadSession.js
@@ -3,6 +3,7 @@ const http = require("http")
 const https = require("https")
 const fs = require("fs")
 const url = require("url")
+const { finished } = require('stream')
 const AbstractDownloadSession = require("./AbstractDownloadSession");
 
 module.exports = class extends AbstractDownloadSession {
@@ -13,14 +14,17 @@ module.exports = class extends AbstractDownloadSession {
         const requestOptions = url.parse(downloadUrl);
         requestOptions.timeout = 3000;
         const httpLibrary = requestOptions.protocol.indexOf("https") === 0 ? https : http;
-        httpLibrary.get(requestOptions, res => {
-            this.lastSecondDownloadedBytes = 0;
-            this.downloadedBytes = 0;
-            this.totalBytes = res.headers["content-length"];
-            this.bytesPerSecond = 0;
-            res.pipe(file);
-            this._handleResponse(res);
-        }).on('error', e => this._emitError(e));
+        finished(
+            httpLibrary.get(requestOptions, res => {
+                this.lastSecondDownloadedBytes = 0;
+                this.downloadedBytes = 0;
+                this.totalBytes = res.headers["content-length"];
+                this.bytesPerSecond = 0;
+                res.pipe(file);
+                this._handleResponse(res);
+            }),
+            e => e && this._emitError(e)
+        );
         this.status = "downloading"
     };
 };


### PR DESCRIPTION
Reason: ClientRequest emits 'aborted', but it was not being handled ([more](https://github.com/nodejs/node/issues/28172)).